### PR TITLE
Fix Reset Skull Caverns having CurseForge ID from Skull Cavern Elevator

### DIFF
--- a/data/data.jsonc
+++ b/data/data.jsonc
@@ -20193,7 +20193,6 @@
 			"name": "Reset Skull Caverns, Skull Caverns Reset",
 			"author": "Sakorona, Kylindra, KoihimeNakamura",
 			"id": "KoihimeNakamura.ResetCaverns",
-			"curse": 990459,
 			"moddrop": 1080116,
 			"nexus": 20846,
 			"github": "Sakorona/SDVMods"

--- a/data/data.jsonc
+++ b/data/data.jsonc
@@ -22052,6 +22052,7 @@
 			"name": "Skull Cavern Elevator",
 			"author": "Bifibi, Lestoph",
 			"id": "SkullCavernElevator",
+			"curse": 990459,
 			"nexus": 963,
 			"github": null
 		},


### PR DESCRIPTION
Rest Skull Caverns has the wrong pointer for Curseforge, pointing to a different mod.