### PR TITLE
Fishing Info Overlays broken in 1.6.14

### DIFF
--- a/data/data.jsonc
+++ b/data/data.jsonc
@@ -9688,7 +9688,8 @@
 			"author": "barteke22",
 			"id": "barteke22.FIshingInfoOverlays",
 			"nexus": 8970,
-			"github": "barteke22/StardewMods"
+			"github": "barteke22/StardewMods",
+			"brokeIn": "Stardew Valley 1.6.14",
 		},
 		{
 			"name": "Fishing Logbook",


### PR DESCRIPTION
Fishing Info Overlays broken in SMAPI 4.1.6 with Stardew Valley 1.6.14 build 24317 on Unix 6.11.8.1