### PR TITLE
Update Migrate DGA Items

### DIFF
--- a/data/data.jsonc
+++ b/data/data.jsonc
@@ -14909,8 +14909,6 @@
 			"id": "violetlizabet.MigrateDGAItems",
 			"nexus": 20612,
 			"github": "elizabethcd/MigrateDGAItems",
-
-			"brokeIn": "Stardew Valley 1.6.9"
 		},
 		{
 			"name": "Milk the Villagers",


### PR DESCRIPTION
I fixed Migrate DGA Items — newest 1.1.0 update on Nexus should be fully compatible