### PR TITLE
update shop tile framework

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -22082,7 +22082,11 @@
 			"id": "Cherry.ShopTileFramework",
 			"nexus": 5005,
 			"moddrop": 716384,
-			"github": "ChroniclerCherry/stardew-valley-mods"
+			"github": "ChroniclerCherry/stardew-valley-mods",
+
+			"brokeIn": "Stardew Valley 1.6",
+			"status": "obsolete",
+			"summary": "remove this mod (no longer maintained; use the game's new built-in shop data instead instead)."
 		},
 		{
 			"name": "Shovel Tool Upgrades, Upgradable Shovel",


### PR DESCRIPTION
⚠ This mod is deprecated in Stardew Valley 1.6 and later. It'll be kept updated to support older content packs, but newer mods should [use the game's new built-in shop data](https://stardewvalleywiki.com/Modding:Shops) instead.
-mod author, https://www.nexusmods.com/stardewvalley/mods/5005?tab=posts