### PR TITLE
Add workaround for Lore-Friendly JojaMart Prices

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -14528,7 +14528,7 @@
 
 			"brokeIn": "Stardew Valley 1.6",
 			"status": "workaround",
-			"summary": "use [Price Buffs](#) instead."
+			"summary": "use [Price Buffs](https://www.nexusmods.com/stardewvalley/mods/16209) instead."
 		},
 		{
 			"name": "Lost Book Menu",
@@ -19342,13 +19342,6 @@
 			"brokeIn": "SMAPI 3.0",
 			"status": "workaround",
 			"summary": "use [CJB Show Item Sell Price](#) instead."
-		},
-		{
-			"name": "Price Buffs",
-			"author": "Bennoloth",
-			"id": "bennoloth.PriceBuffs",
-			"nexus": 16209,
-			"github": null
 		},
 		{
 			"name": "Price Tooltips",

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -14526,7 +14526,10 @@
 			"nexus": 2658,
 			"github": null,
 
-			"brokeIn": "Stardew Valley 1.6"
+			"brokeIn": "Stardew Valley 1.6",
+			"status": "workaround",
+			"summary": "use [Price Buffs](#) instead."
+		},
 		},
 		{
 			"name": "Lost Book Menu",
@@ -19340,6 +19343,13 @@
 			"brokeIn": "SMAPI 3.0",
 			"status": "workaround",
 			"summary": "use [CJB Show Item Sell Price](#) instead."
+		},
+		{
+			"name": "Price Buffs",
+			"author": "Bennoloth",
+			"id": "bennoloth.pricebuffs",
+			"nexus": 16209,
+			"github": null
 		},
 		{
 			"name": "Price Tooltips",

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -14530,7 +14530,6 @@
 			"status": "workaround",
 			"summary": "use [Price Buffs](#) instead."
 		},
-		},
 		{
 			"name": "Lost Book Menu",
 			"author": "bungus",
@@ -19347,7 +19346,7 @@
 		{
 			"name": "Price Buffs",
 			"author": "Bennoloth",
-			"id": "bennoloth.pricebuffs",
+			"id": "bennoloth.PriceBuffs",
 			"nexus": 16209,
 			"github": null
 		},


### PR DESCRIPTION
Made the following modifications:
- Added new mod: "Price Buffs"
- Added workaround for mod "Lore-Friendly JojaMart Prices" linking to "Price Buffs"
(It has a "lore-friendly JojaMart Prices option as of April 2024.)

(Man, I hope I did this right…)