### PR TITLE
Add workaround for Better Quality More Seeds

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -2634,7 +2634,9 @@
 			"nexus": 935,
 			"github": "bmarquismarkail/SV_BetterQualityMoreSeeds",
 
-			"brokeIn": "Stardew Valley 1.6"
+			"brokeIn": "Stardew Valley 1.6",
+			"status": "workaround",
+			"summary": "use [Seed Maker Quality](#) instead."
 		},
 		{
 			"name": "Better Quarry",


### PR DESCRIPTION
In "Better Quality More Seeds" mod entry, added workaround to use "Seed Maker Quality" instead.