### PR TITLE
Mark Remember Faced Direction as broken with unofficial update

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -22551,7 +22551,7 @@
 			"brokeIn": "Stardew Valley 1.6.15",
 			"unofficialUpdate": {
 				"version": "1.1.2-unofficial.1-adro",
-				"url": "http://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/post-179378"
+				"url": "https://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/post-179378"
 			}
 		},
 		{

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -22548,7 +22548,7 @@
 			"nexus": 6946,
 			"github": "Annosz/StardewValleyModding",
 
-			"brokeIn": "Stardew Valley 1.6.15",
+			"brokeIn": "Stardew Valley 1.6.9",
 			"unofficialUpdate": {
 				"version": "1.1.2-unofficial.1-adro",
 				"url": "https://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/post-179378"

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -22546,7 +22546,13 @@
 			"author": "Annosz",
 			"id": "Annosz.RememberFacedDirection",
 			"nexus": 6946,
-			"github": "Annosz/StardewValleyModding"
+			"github": "Annosz/StardewValleyModding",
+
+			"brokeIn: "Stardew Valley 1.6.15",
+			"unofficialUpdate": {
+				"version": "1.1.2-unofficial.1-adro",
+				"url": "http://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/post-179378"
+			}
 		},
 		{
 			"name": "Remember Your Umbrella",

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -22548,7 +22548,7 @@
 			"nexus": 6946,
 			"github": "Annosz/StardewValleyModding",
 
-			"brokeIn: "Stardew Valley 1.6.15",
+			"brokeIn": "Stardew Valley 1.6.15",
 			"unofficialUpdate": {
 				"version": "1.1.2-unofficial.1-adro",
 				"url": "http://forums.stardewvalley.net/threads/unofficial-mod-updates.2096/post-179378"


### PR DESCRIPTION
The original mod failed a harmony patch, the fix was a simple disambiguation. PR to original is pending but unlikely to be accepted soon.