### PR TITLE
Update status for Seed Machines

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -23697,9 +23697,7 @@
 			"author": "Veress",
 			"id": "Veress.SeedMachines",
 			"nexus": 6265,
-			"github": "mrveress/SDVMods",
-
-			"brokeIn": "Stardew Valley 1.6"
+			"github": "mrveress/SDVMods"
 		},
 		{
 			"name": "Seed Maker - Better Quality More Seeds",


### PR DESCRIPTION
Seed Machines was fixed for 1.6+ SV and 4.x.x SMAPI and updated in Nexus