### PR TITLE
Update workaround for Big Silo to use Equivalent Silo

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -3016,7 +3016,7 @@
 			"brokeIn": "Stardew Valley 1.3.29",
 			"status": "abandoned",
 			"abandonedReason": "hidden",
-			"summary": "remove this mod (no longer maintained; use [More Bar Transmutation](https://www.nexusmods.com/stardewvalley/mods/5996)  instead)."
+			"summary": "remove this mod (no longer maintained; use [More Bar Transmutation](https://www.nexusmods.com/stardewvalley/mods/5996) instead)."
 		},
 		{
 			"name": "Better Trash Can",
@@ -3182,7 +3182,7 @@
 
 			"brokeIn": "SMAPI 3.12.0",
 			"status": "workaround",
-			"summary": "use [Equivalent Silo](#) instead.",
+			"summary": "use [Equivalent Silo](https://www.nexusmods.com/stardewvalley/mods/21242) instead."
 
 			"overrideModData": [
 				{

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -3182,7 +3182,7 @@
 
 			"brokeIn": "SMAPI 3.12.0",
 			"status": "workaround",
-			"summary": "use [Equivalent Silo](#) instead."
+			"summary": "use [Equivalent Silo](#) instead.",
 
 			"overrideModData": [
 				{

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -3182,7 +3182,7 @@
 
 			"brokeIn": "SMAPI 3.12.0",
 			"status": "workaround",
-			"summary": "use [Equivalent Silo](https://www.nexusmods.com/stardewvalley/mods/21242) instead."
+			"summary": "use [Equivalent Silo](https://www.nexusmods.com/stardewvalley/mods/21242) instead.",
 
 			"overrideModData": [
 				{

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -3181,6 +3181,8 @@
 			"developerNotes": "source in download",
 
 			"brokeIn": "SMAPI 3.12.0",
+			"status": "workaround",
+			"summary": "use [Equivalent Silo](#) instead."
 
 			"overrideModData": [
 				{


### PR DESCRIPTION
I don't see Equivalent Silo on the list, but it's linked from my NexusMod entry for BigSilo. 