### PR TITLE
Add Teh's Fishing Overhaul Revived & update workarounds

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -29498,7 +29498,7 @@
 
 			"brokeIn": "Stardew Valley 1.6",
 			"status": "workaround",
-			"summary": "use the version provided in [Teh's Fishing Overhaul Revived](#) instead."
+			"summary": "use [Teh's Fishing Overhaul Revived](#) instead."
 		},
 		{
 			"name": "Teh's Festive Slimes",
@@ -29519,14 +29519,14 @@
 
 			"brokeIn": "Stardew Valley 1.6",
 			"status": "workaround",
-			"summary": "use the continuation of this mod: [Teh's Fishing Overhaul Revived](#) instead."
+			"summary": "use [Teh's Fishing Overhaul Revived](#) instead."
 		},
 		{
 			"name": "Teh's Fishing Overhaul Revived",
 			"author": "Hiztaar",
 			"id": "Hiztaar.TehPersFishingOverhaulRevived",
 			"nexus": 40885,
-			"github": "https://github.com/Hiztaar/TehsStardewValleyMods_1.6Revived",
+			"github": "Hiztaar/TehsStardewValleyMods_1.6Revived",
 		},
 		{
 			"name": "Telephone Purchasing",

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -29524,7 +29524,7 @@
 		{
 			"name": "Teh's Fishing Overhaul Revived",
 			"author": "Hiztaar",
-			"id": "TehPers.FishingOverhaul",
+			"id": "Hiztaar.TehPersFishingOverhaulRevived",
 			"nexus": 40885,
 			"github": "https://github.com/Hiztaar/TehsStardewValleyMods_1.6Revived",
 		},

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -29497,10 +29497,8 @@
 			"github": "TehPers/StardewValleyMods",
 
 			"brokeIn": "Stardew Valley 1.6",
-			"unofficialUpdate": {
-				"version": "1.1.2-unofficial.3-Hiztaar",
-				"url": "https://github.com/Hiztaar/TehsStardewValleyMods_1.6Revived/releases/tag/3.3.5-unofficial.3-Hiztaar"
-			}
+			"status": "workaround",
+			"summary": "use the version provided in [Teh's Fishing Overhaul Revived](#) instead."
 		},
 		{
 			"name": "Teh's Festive Slimes",
@@ -29520,10 +29518,15 @@
 			"github": "TehPers/StardewValleyMods",
 
 			"brokeIn": "Stardew Valley 1.6",
-			"unofficialUpdate": {
-				"version": "3.3.5-unofficial.3-Hiztaar",
-				"url": "https://github.com/Hiztaar/TehsStardewValleyMods_1.6Revived/releases/tag/3.3.5-unofficial.3-Hiztaar"
-			}
+			"status": "workaround",
+			"summary": "use the continuation of this mod: [Teh's Fishing Overhaul Revived](#) instead."
+		},
+		{
+			"name": "Teh's Fishing Overhaul Revived",
+			"author": "Hiztaar",
+			"id": "TehPers.FishingOverhaul",
+			"nexus": 40885,
+			"github": "https://github.com/Hiztaar/TehsStardewValleyMods_1.6Revived",
 		},
 		{
 			"name": "Telephone Purchasing",


### PR DESCRIPTION
…updates to the Revived official version on Nexus

Removed unofficial update information on Teh's Core and Fishing Overhaul. Replaced with workaround and summary pointing to Teh's Fishing Overhaul Revived (which contains both Core and Fishing Overhaul files) Added Teh's Fishing Overhaul Revived (on Nexus) by Hiztaar.