### PR TITLE
Add workaround for Combat Level Damage Scaler

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -5480,7 +5480,8 @@
 			"nexus": 3905,
 			"github": "spacechase0/StardewValleyMods",
 
-			"brokeIn": "Stardew Valley 1.6"
+			"brokeIn": "Stardew Valley 1.6",
+			"status": "workaround",
 			"summary": "use [Damage Scaler](#) instead."
 		},
 		{

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -5481,6 +5481,7 @@
 			"github": "spacechase0/StardewValleyMods",
 
 			"brokeIn": "Stardew Valley 1.6"
+			"summary": "use [Damage Scaler](#) instead."
 		},
 		{
 			"name": "Combat with Farming Implements",


### PR DESCRIPTION
spacechase0 archived it in their repo and its broken in 1.6, adding a pointer to my mod which does the same thing.