### PR TITLE
Split 'Portraits For All' into its own entry, remove 'They Deserve It Too' (no longer a C# mod)

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -24992,13 +24992,11 @@
 			"brokeIn": "Stardew Valley 1.6"
 		},
 		{
-			"name": "PortraitsForAll",
+			"name": "Portraits For All",
 			"author": "mushymato",
 			"id": "mushymato.PortraitsForAll",
 			"nexus": null,
-			"github": "Mushymato/PortraitsForAll",
-
-			"summary": "also bundled in [They Deserve It Too - Portraits for Extras](https://www.nexusmods.com/stardewvalley/mods/35358), but the GitHub release maintains accurate versioning."
+			"github": "Mushymato/PortraitsForAll"
 		},
 		{
 			"name": "Portraiture",

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -33133,17 +33133,6 @@
 			"github": null
 		},
 		{
-			"name": "They Deserve It Too - Dialogue Box for Mariner",
-			"author": "KediDili and Dolphin Is Not a Fish",
-			"id": "DolphINaF.Kedi.MarinerDialogue, Dolphin.Kedi.OldMarinerDialogue", // changed in 1.1.0
-			"nexus": 20414,
-			"github": null,
-
-			"status": "abandoned",
-			"abandonedReason": "author",
-			"summary": "remove this mod (no longer maintained; use [PortraitsForAll](https://github.com/Mushymato/PortraitsForAll) instead)."
-		},
-		{
 			"name": "They Thrive",
 			"author": "John Peters",
 			"id": "JohnPeters.TheyThrive",

--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -24992,6 +24992,15 @@
 			"brokeIn": "Stardew Valley 1.6"
 		},
 		{
+			"name": "PortraitsForAll",
+			"author": "mushymato",
+			"id": "mushymato.PortraitsForAll",
+			"nexus": null,
+			"github": "Mushymato/PortraitsForAll",
+
+			"summary": "also bundled in [They Deserve It Too - Portraits for Extras](https://www.nexusmods.com/stardewvalley/mods/35358), but the GitHub release maintains accurate versioning."
+		},
+		{
 			"name": "Portraiture",
 			"author": "Platonymous",
 			"id": "Platonymous.Portraiture",
@@ -33126,18 +33135,15 @@
 			"github": null
 		},
 		{
-			"name": "They Deserve It Too, Portraits For All",
-			"author": "cresolyn and Dolphin Is Not a Fish, mushymato",
-			"id": "mushymato.PortraitsForAll",
-			"nexus": 35358,
-			"github": "Mushymato/PortraitsForAll"
-		},
-		{
-			"name": "They Deserve It Too - Portraits for Vendors, TDIT - Dialogue Box for Mariner",
-			"author": "Dolphin Is Not a Fish",
+			"name": "They Deserve It Too - Dialogue Box for Mariner",
+			"author": "KediDili and Dolphin Is Not a Fish",
 			"id": "DolphINaF.Kedi.MarinerDialogue, Dolphin.Kedi.OldMarinerDialogue", // changed in 1.1.0
 			"nexus": 20414,
-			"github": null
+			"github": null,
+
+			"status": "abandoned",
+			"abandonedReason": "author",
+			"summary": "remove this mod (no longer maintained; use [PortraitsForAll](https://github.com/Mushymato/PortraitsForAll) instead)."
 		},
 		{
 			"name": "They Thrive",


### PR DESCRIPTION
Dialogue Box for Mariner is abandoned and isn't available anymore.

PortraitsForAll is available on both Nexus and GitHub, but on Nexus it's bundled with Portraits for Extras and uses a different version number. I suggest linking to the GitHub version instead, as it has the correct versioning and prevents SMAPI from incorrectly prompting updates.