### PR TITLE
Add 'Multi Save Checkpoint' mods

### DIFF
--- a/data/mods.jsonc
+++ b/data/mods.jsonc
@@ -21868,6 +21868,20 @@
 			"github": "recon88/Multi-Save-Continued"
 		},
 		{
+		  "name": "Multi Save Checkpoint - Standard Edition",
+		  "author": "NoobSama101",
+		  "id": "NoobSama101.MultiSaveCheckpoint",
+		  "nexus": 45258,
+		  "github": null
+		},
+		{
+		  "name": "Multi Save Checkpoint - QuickSave Edition",
+		  "author": "NoobSama101",
+		  "id": "NoobSama101.MultiSaveCheckpointQuickSaveEdition",
+		  "nexus": 45258,
+		  "github": null
+		},
+		{
 			"name": "MultiSleep",
 			"author": "Kaito Kid",
 			"id": "KaitoKid.ArchipelagoStandaloneMods.MultiSleep",


### PR DESCRIPTION
Adds compatibility metadata for both editions of Multi Save Checkpoint.

Mods added:
- Multi Save Checkpoint - Standard Edition
  - UniqueID: NoobSama101.MultiSaveCheckpoint
  - Nexus: 45258
  - Requires: Multi Save - Continued

- Multi Save Checkpoint - QuickSave Edition
  - UniqueID: NoobSama101.MultiSaveCheckpointQuickSaveEdition
  - Nexus: 45258
  - Requires: Multi Save - Continued and QuickSave (Save Midday)

Both editions are hosted on the same Nexus Mods page and use SMAPI update subkeys in their manifests/Nexus file descriptions.